### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ tokens/
 drivedl.egg-info/
 dist/
 build/
+venv/
+.idea/
 
 credentials.json
 config.json

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Note that on the first run, you will have to authorize the scope of the applicat
 Adding an argument `--skip` to your command will skip existing files and not redownload them.
 - By default the behaviour is to download everything without skipping.
 
+## File Abuse
+
+Adding an argument `--abuse` allows for downloading files which have been marked as "abused" from google.
+This acknowledges that you will download a file which google has marked that it could be malware or spam.
+An example error can be found on [this](https://github.com/prasmussen/gdrive/issues/182).
+
 ## Assigning extra processes:
 
 Adding an argument `--proc` followed by an integer of processes to assign the application will spawn the specified processes to do the download. Default process count is 5 processes

--- a/drivedl/drivedl.py
+++ b/drivedl/drivedl.py
@@ -83,6 +83,7 @@ def main(console_call=True):
     search = False
     skip = False
     noiter = False
+    abuse = False
 
     # File Listing
     if len(sys.argv) < 2:
@@ -102,6 +103,9 @@ def main(console_call=True):
         if '--skip' in sys.argv:
             skip = True
             sys.argv.remove('--skip')
+        if '--abuse' in sys.argv:
+            abuse = True
+            sys.argv.remove('--abuse')
         if '--debug' in sys.argv:
             util.DEBUG = True
             sys.argv.remove('--debug')
@@ -134,7 +138,8 @@ def main(console_call=True):
                 path = ["".join([c for c in dirname if c.isalpha() or c.isdigit() or c in [' ', '-', '_', '.', '(', ')', '[', ']']]).rstrip() for dirname in path]
                 for f in files:
                     dest = os.path.join(destination, os.path.join(*path))
-                    file_dest.append((service, f, dest, skip))
+                    f['name'] = "".join([c for c in f['name'] if c.isalpha() or c.isdigit() or c in [' ', '-', '_', '.', '(', ')', '[', ']']]).rstrip()
+                    file_dest.append((service, f, dest, skip, abuse))
             if file_dest != []:
                 # First valid account found, break to prevent further searches
                 return True
@@ -142,7 +147,7 @@ def main(console_call=True):
             dlfile = service.files().get(fileId=folderid, supportsAllDrives=True).execute()
             print(f"\nNot a valid folder ID. \nDownloading the file : {dlfile['name']}")
             # Only use a single process for downloading 1 file
-            util.download(service, dlfile, destination, skip)
+            util.download(service, dlfile, destination, skip, abuse)
             sys.exit(0)
         except HttpError:
             print(f"{Fore.RED}File not found in account: {acc}{Style.RESET_ALL}")
@@ -171,7 +176,8 @@ def main(console_call=True):
 
     if service == None:
         # No accounts found with access to the drive link, exit gracefully
-        print("No valid accounts with access to the file/folder. Exiting...")
+        print("No valid accounts with access to the file/folder.")
+        print("Have you run the drivedl --add command? Exiting...")
         sys.exit(1)
     try:
         p = Pool(PROCESS_COUNT)


### PR DESCRIPTION
This adds some key changes that I required to get it to work.
- Now also only accept a subset of valid chars for folder names (directories were already cleaned)
- This should close issue https://github.com/architdate/drivedl/issues/5
- Abuse flag added in https://github.com/architdate/drivedl/pull/2 will prevent download of non-abuse files.
- Changed abuse flag to not default true, and pass as a parameter `--abuse`
- Also if no file ending is set for google mime types, then set default ones (.pptx, xlsx, .docx)
- This allows for direct opening without having to remember what file type the file is when downloaded (by default they don't have file endings when created in the web interface).
